### PR TITLE
Add glance support

### DIFF
--- a/source/PaceCalculatorApp.mc
+++ b/source/PaceCalculatorApp.mc
@@ -4,6 +4,7 @@ import Toybox.WatchUi;
 
 //! The PaceCalculator app is an app that can convert between pace (min/km) and
 //! speed (km/h).
+(:typecheck(false))
 class PaceCalculatorApp extends Application.AppBase {
     private var _speedConverter as SpeedConverter;
 
@@ -25,6 +26,16 @@ class PaceCalculatorApp extends Application.AppBase {
             new PaceCalculatorView(_speedConverter),
             new PaceCalculatorDelegate(_speedConverter),
         ];
+    }
+
+    (:glance)
+    function getGlanceView() {
+        return [new PaceCalculatorGlanceView(_speedConverter)];
+    }
+
+    (:glance)
+    function getGlanceTheme() as AppBase.GlanceTheme {
+        return AppBase.GLANCE_THEME_GOLD;
     }
 }
 

--- a/source/PaceCalculatorGlanceView.mc
+++ b/source/PaceCalculatorGlanceView.mc
@@ -1,0 +1,36 @@
+import Toybox.Application.Storage;
+import Toybox.Application;
+import Toybox.Communications;
+import Toybox.Graphics;
+import Toybox.Lang;
+import Toybox.WatchUi;
+
+(:glance)
+class PaceCalculatorGlanceView extends WatchUi.GlanceView {
+    private var _speedConverter as SpeedConverter;
+
+    function initialize(sc as SpeedConverter) {
+        _speedConverter = sc;
+        GlanceView.initialize();
+    }
+
+    function getLayout() as Void {}
+
+    function onUpdate(dc) {
+        dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_TRANSPARENT);
+        dc.drawText(
+            0,
+            dc.getHeight() / 3,
+            Graphics.FONT_TINY,
+            Lang.format("$1$ min/km", [_speedConverter.pace]),
+            Graphics.TEXT_JUSTIFY_LEFT | Graphics.TEXT_JUSTIFY_VCENTER
+        );
+        dc.drawText(
+            0,
+            dc.getHeight() / 1.5,
+            Graphics.FONT_TINY,
+            Lang.format("$1$ km/h", [_speedConverter.speed.format("%.1f")]),
+            Graphics.TEXT_JUSTIFY_LEFT | Graphics.TEXT_JUSTIFY_VCENTER
+        );
+    }
+}

--- a/source/SpeedConverter.mc
+++ b/source/SpeedConverter.mc
@@ -6,6 +6,7 @@ import Toybox.Application.Storage;
 //! Every time either is set, the corresponding value will be updated. This will
 //! also set the picker defaults (arrays) so the next time a picker is selected
 //! the right defautl values are used.
+(:glance)
 class SpeedConverter {
     var speed as Float;
     var pace as String;


### PR DESCRIPTION
This will add glance support for SDK 4.0.0+. However, for it to work as a widget for older devices/versions, we would have to change the app type to a widget. From what I can tell, this [isn't possible](https://forums.garmin.com/developer/connect-iq/f/discussion/351754/is-it-possible-to-change-the-app-type-of-a-released-app).

I've created [an issue/feature request](https://forums.garmin.com/developer/connect-iq/i/bug-reports/feature-request-allow-to-change-app-type) to get an official confirmation.

If it's not possible to change app types I would have to take down the current app and upload a new one which would be a shame, or just don't support it for pre 4.0.0 devices which is also not great. Let's wait and se...

Closes #2 